### PR TITLE
Fix typographical errors in tests

### DIFF
--- a/Tests/GoogleAITests/PartsRepresentableTests.swift
+++ b/Tests/GoogleAITests/PartsRepresentableTests.swift
@@ -110,7 +110,7 @@
             return
           }
         }
-        XCTFail("Expected model content from invlaid image to error")
+        XCTFail("Expected model content from invalid image to error")
       }
 
       func testModelContentFromUIImageIsNotEmpty() throws {
@@ -168,7 +168,7 @@
             return
           }
         }
-        XCTFail("Expected model content from invlaid image to error")
+        XCTFail("Expected model content from invalid image to error")
       }
     #endif
   }


### PR DESCRIPTION
## Summary
- fix misspellings in image error test messages

## Testing
- `codespell -q 3 -f`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_689e31fe3f948333b3f6b1cf8c46d78d