### PR TITLE
feat: expose GenChatUI target

### DIFF
--- a/Examples/GenerativeAISample/ChatSample/ChatSampleApp.swift
+++ b/Examples/GenerativeAISample/ChatSample/ChatSampleApp.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import SwiftUI
+import GenChatUI
 
 @main
 struct ChatSampleApp: App {

--- a/Package.swift
+++ b/Package.swift
@@ -19,11 +19,13 @@ import PackageDescription
 ConfigurationService.local.dependencies = [
   .package(name: "WrkstrmLog", path: "../WrkstrmLog"),
   .package(name: "WrkstrmFoundation", path: "../WrkstrmFoundation"),
+  .package(url: "https://github.com/gonzalezreal/MarkdownUI.git", from: "2.4.0"),
 ]
 
 ConfigurationService.remote.dependencies = [
   .package(url: "https://github.com/wrkstrm/WrkstrmLog.git", from: "2.0.0"),
   .package(url: "https://github.com/wrkstrm/WrkstrmFoundation.git", from: "2.0.0"),
+  .package(url: "https://github.com/gonzalezreal/MarkdownUI.git", from: "2.4.0"),
 ]
 
 let package = Package(
@@ -37,7 +39,11 @@ let package = Package(
     .library(
       name: "GoogleGenerativeAI",
       targets: ["GoogleGenerativeAI"],
-    )
+    ),
+    .library(
+      name: "GenChatUI",
+      targets: ["GenChatUI"],
+    ),
   ],
   dependencies: ConfigurationService.inject.dependencies,
   targets: [
@@ -48,7 +54,15 @@ let package = Package(
         .product(name: "WrkstrmNetworking", package: "WrkstrmFoundation"),
         .product(name: "WrkstrmLog", package: "WrkstrmLog"),
       ],
-      path: "Sources",
+      path: "Sources/GoogleAI",
+    ),
+    .target(
+      name: "GenChatUI",
+      dependencies: [
+        "GoogleGenerativeAI",
+        .product(name: "MarkdownUI", package: "MarkdownUI", condition: .when(platforms: [.iOS, .macOS, .macCatalyst]))
+      ],
+      path: "Sources/GenChatUI"
     ),
     .testTarget(
       name: "GoogleGenerativeAITests",

--- a/Sources/GenChatUI/Models/ChatMessage.swift
+++ b/Sources/GenChatUI/Models/ChatMessage.swift
@@ -12,25 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(SwiftUI)
 import Foundation
 
-enum Participant {
+public enum Participant {
   case system
   case user
 }
 
-struct ChatMessage: Identifiable, Equatable {
-  let id = UUID().uuidString
-  var message: String
-  let participant: Participant
-  var pending = false
+public struct ChatMessage: Identifiable, Equatable {
+  public let id = UUID().uuidString
+  public var message: String
+  public let participant: Participant
+  public var pending = false
 
-  static func pending(participant: Participant) -> ChatMessage {
+  public init(message: String, participant: Participant, pending: Bool = false) {
+    self.message = message
+    self.participant = participant
+    self.pending = pending
+  }
+
+  public static func pending(participant: Participant) -> ChatMessage {
     Self(message: "", participant: participant, pending: true)
   }
 }
 
-extension ChatMessage {
+public extension ChatMessage {
   static var samples: [ChatMessage] = [
     .init(message: "Hello. What can I do for you today?", participant: .system),
     .init(message: "Show me a simple loop in Swift.", participant: .user),
@@ -71,3 +78,5 @@ extension ChatMessage {
 
   static var sample = samples[0]
 }
+
+#endif

--- a/Sources/GenChatUI/Screens/ConversationScreen.swift
+++ b/Sources/GenChatUI/Screens/ConversationScreen.swift
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import GenerativeAIUIComponents
-import GoogleGenerativeAI
+#if canImport(SwiftUI)
 import SwiftUI
 
-struct ConversationScreen: View {
+public struct ConversationScreen: View {
   @EnvironmentObject
   var viewModel: ConversationViewModel
 
@@ -130,3 +129,5 @@ struct ConversationScreen_Previews: PreviewProvider {
     }
   }
 }
+
+#endif

--- a/Sources/GenChatUI/ViewModels/ConversationViewModel.swift
+++ b/Sources/GenChatUI/ViewModels/ConversationViewModel.swift
@@ -12,20 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(SwiftUI)
 import Foundation
+import SwiftUI
 import GoogleGenerativeAI
-import UIKit
 
 @MainActor
-class ConversationViewModel: ObservableObject {
+public class ConversationViewModel: ObservableObject {
   /// This array holds both the user's and the system's chat messages
-  @Published var messages: [ChatMessage] = []
+  @Published public var messages: [ChatMessage] = []
 
   /// Indicates we're waiting for the model to finish
-  @Published var busy = false
+  @Published public var busy = false
 
-  @Published var error: Error?
-  var hasError: Bool {
+  @Published public var error: Error?
+  public var hasError: Bool {
     error != nil
   }
 
@@ -35,12 +36,12 @@ class ConversationViewModel: ObservableObject {
 
   private var chatTask: Task<Void, Never>?
 
-  init() {
+  public init() {
     model = GenerativeModel(name: "gemini-1.5-flash-latest", apiKey: APIKey.default)
     chat = model.startChat()
   }
 
-  func sendMessage(_ text: String, streaming: Bool = true) async {
+  public func sendMessage(_ text: String, streaming: Bool = true) async {
     error = nil
     if streaming {
       await internalSendMessageStreaming(text)
@@ -49,14 +50,14 @@ class ConversationViewModel: ObservableObject {
     }
   }
 
-  func startNewChat() {
+  public func startNewChat() {
     stop()
     error = nil
     chat = model.startChat()
     messages.removeAll()
   }
 
-  func stop() {
+  public func stop() {
     chatTask?.cancel()
     error = nil
   }
@@ -128,3 +129,5 @@ class ConversationViewModel: ObservableObject {
     }
   }
 }
+
+#endif

--- a/Sources/GenChatUI/Views/BouncingDots.swift
+++ b/Sources/GenChatUI/Views/BouncingDots.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 struct BouncingDots: View {
@@ -75,3 +76,5 @@ struct BouncingDots_Previews: PreviewProvider {
       .roundedCorner(10, corners: [.allCorners])
   }
 }
+
+#endif

--- a/Sources/GenChatUI/Views/ErrorDetailsView.swift
+++ b/Sources/GenChatUI/Views/ErrorDetailsView.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(SwiftUI)
 import GoogleGenerativeAI
 import MarkdownUI
 import SwiftUI
@@ -85,7 +86,7 @@ private struct SafetyRatingsSection: View {
   }
 }
 
-struct ErrorDetailsView: View {
+public struct ErrorDetailsView: View {
   var error: Error
 
   var body: some View {
@@ -264,3 +265,5 @@ struct ErrorDetailsView: View {
 #Preview("Unsupported User Location") {
   ErrorDetailsView(error: GenerateContentError.unsupportedUserLocation)
 }
+
+#endif

--- a/Sources/GenChatUI/Views/ErrorView.swift
+++ b/Sources/GenChatUI/Views/ErrorView.swift
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(SwiftUI)
 import GoogleGenerativeAI
 import SwiftUI
 
-struct ErrorView: View {
+public struct ErrorView: View {
   var error: Error
   @State private var isDetailsSheetPresented = false
   var body: some View {
@@ -71,3 +72,5 @@ struct ErrorView: View {
     .navigationTitle("Chat sample")
   }
 }
+
+#endif

--- a/Sources/GenChatUI/Views/InputField.swift
+++ b/Sources/GenChatUI/Views/InputField.swift
@@ -1,0 +1,85 @@
+#if canImport(SwiftUI)
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+public struct InputField<Label>: View where Label: View {
+  @Binding
+  private var text: String
+
+  private var title: String?
+  private var label: () -> Label
+
+  @Environment(\.submitHandler)
+  var submitHandler
+
+  private func submit() {
+    if let submitHandler {
+      submitHandler()
+    }
+  }
+
+  public init(
+    _ title: String? = nil, text: Binding<String>,
+    @ViewBuilder label: @escaping () -> Label,
+  ) {
+    self.title = title
+    _text = text
+    self.label = label
+  }
+
+  public var body: some View {
+    VStack(alignment: .leading) {
+      HStack(alignment: .bottom) {
+        VStack(alignment: .leading) {
+          TextField(
+            title ?? "",
+            text: $text,
+            axis: .vertical,
+          )
+          .padding(.vertical, 4)
+          .onSubmit(submit)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .overlay {
+          RoundedRectangle(
+            cornerRadius: 8,
+            style: .continuous,
+          )
+#if canImport(UIKit)
+          .stroke(Color(uiColor: .systemFill), lineWidth: 1)
+#elseif canImport(AppKit)
+          .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+#else
+          .stroke(Color.secondary, lineWidth: 1)
+#endif
+        }
+
+        Button(action: submit, label: label)
+          .padding(.bottom, 4)
+      }
+    }
+    .padding(8)
+  }
+}
+
+#Preview {
+  struct Wrapper: View {
+    @State var userInput: String = ""
+
+    var body: some View {
+      InputField("Message", text: $userInput) {
+        Image(systemName: "arrow.up.circle.fill")
+          .font(.title)
+      }
+    }
+  }
+
+  return Wrapper()
+}
+
+#endif

--- a/Sources/GenChatUI/Views/MessageView.swift
+++ b/Sources/GenChatUI/Views/MessageView.swift
@@ -12,28 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(SwiftUI)
 import MarkdownUI
 import SwiftUI
-
-struct RoundedCorner: Shape {
-  var radius: CGFloat = .infinity
-  var corners: UIRectCorner = .allCorners
-
-  func path(in rect: CGRect) -> Path {
-    let path = UIBezierPath(
-      roundedRect: rect,
-      byRoundingCorners: corners,
-      cornerRadii: CGSize(width: radius, height: radius),
-    )
-    return Path(path.cgPath)
-  }
-}
-
-extension View {
-  func roundedCorner(_ radius: CGFloat, corners: UIRectCorner) -> some View {
-    clipShape(RoundedCorner(radius: radius, corners: corners))
-  }
-}
 
 struct MessageContentView: View {
   var message: ChatMessage
@@ -46,7 +27,7 @@ struct MessageContentView: View {
         .markdownTextStyle {
           FontFamilyVariant(.normal)
           FontSize(.em(0.85))
-          ForegroundColor(message.participant == .system ? Color(UIColor.label) : .white)
+          ForegroundColor(message.participant == .system ? Color.primary : .white)
         }
         .markdownBlockStyle(\.codeBlock) { configuration in
           configuration.label
@@ -54,10 +35,10 @@ struct MessageContentView: View {
             .markdownTextStyle {
               FontFamilyVariant(.monospaced)
               FontSize(.em(0.85))
-              ForegroundColor(Color(.label))
+              ForegroundColor(Color.primary)
             }
             .padding()
-            .background(Color(.secondarySystemBackground))
+            .background(Color.secondary.opacity(0.1))
             .clipShape(RoundedRectangle(cornerRadius: 8))
             .markdownMargin(top: .zero, bottom: .em(0.8))
         }
@@ -65,7 +46,7 @@ struct MessageContentView: View {
   }
 }
 
-struct MessageView: View {
+public struct MessageView: View {
   var message: ChatMessage
 
   var body: some View {
@@ -77,8 +58,8 @@ struct MessageView: View {
         .padding(10)
         .background(
           message.participant == .system
-            ? Color(UIColor.systemFill)
-            : Color(UIColor.systemBlue),
+            ? Color.gray.opacity(0.2)
+            : Color.accentColor,
         )
         .roundedCorner(
           10,
@@ -110,3 +91,5 @@ struct MessageView_Previews: PreviewProvider {
     }
   }
 }
+
+#endif

--- a/Sources/GenChatUI/Views/RectCorner.swift
+++ b/Sources/GenChatUI/Views/RectCorner.swift
@@ -1,0 +1,11 @@
+#if canImport(SwiftUI)
+struct RectCorner: OptionSet {
+  let rawValue: Int
+
+  static let topLeft = RectCorner(rawValue: 1 << 0)
+  static let topRight = RectCorner(rawValue: 1 << 1)
+  static let bottomLeft = RectCorner(rawValue: 1 << 2)
+  static let bottomRight = RectCorner(rawValue: 1 << 3)
+  static let allCorners: RectCorner = [.topLeft, .topRight, .bottomLeft, .bottomRight]
+}
+#endif

--- a/Sources/GenChatUI/Views/RoundedCorner.swift
+++ b/Sources/GenChatUI/Views/RoundedCorner.swift
@@ -1,0 +1,52 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+struct RoundedCorner: Shape {
+  var radius: CGFloat = .infinity
+  var corners: RectCorner = .allCorners
+
+  func path(in rect: CGRect) -> Path {
+    var path = Path()
+
+    let tl = corners.contains(.topLeft) ? radius : 0
+    let tr = corners.contains(.topRight) ? radius : 0
+    let bl = corners.contains(.bottomLeft) ? radius : 0
+    let br = corners.contains(.bottomRight) ? radius : 0
+
+    path.move(to: CGPoint(x: rect.minX + tl, y: rect.minY))
+    path.addLine(to: CGPoint(x: rect.maxX - tr, y: rect.minY))
+    if tr > 0 {
+      path.addArc(center: CGPoint(x: rect.maxX - tr, y: rect.minY + tr),
+                  radius: tr,
+                  startAngle: .degrees(-90), endAngle: .degrees(0), clockwise: false)
+    }
+    path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - br))
+    if br > 0 {
+      path.addArc(center: CGPoint(x: rect.maxX - br, y: rect.maxY - br),
+                  radius: br,
+                  startAngle: .degrees(0), endAngle: .degrees(90), clockwise: false)
+    }
+    path.addLine(to: CGPoint(x: rect.minX + bl, y: rect.maxY))
+    if bl > 0 {
+      path.addArc(center: CGPoint(x: rect.minX + bl, y: rect.maxY - bl),
+                  radius: bl,
+                  startAngle: .degrees(90), endAngle: .degrees(180), clockwise: false)
+    }
+    path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + tl))
+    if tl > 0 {
+      path.addArc(center: CGPoint(x: rect.minX + tl, y: rect.minY + tl),
+                  radius: tl,
+                  startAngle: .degrees(180), endAngle: .degrees(270), clockwise: false)
+    }
+
+    path.closeSubpath()
+    return path
+  }
+}
+
+extension View {
+  func roundedCorner(_ radius: CGFloat, corners: RectCorner) -> some View {
+    clipShape(RoundedCorner(radius: radius, corners: corners))
+  }
+}
+#endif


### PR DESCRIPTION
## Summary
- rename ChatUI library and target to GenChatUI
- update ChatSample example to import GenChatUI module
- remove outdated license header from InputField view
- extract RectCorner and RoundedCorner utilities into dedicated files without Google attribution
- restore Apache license header in MessageView view

## Testing
- `swift test` *(fails: type 'AI.GoogleGenAI.Environment' does not conform to protocol 'HTTP.Environment')*


------
https://chatgpt.com/codex/tasks/task_e_68ad71ed641883339491a65677d64a4a