### PR TITLE
docs: add agency update standard

### DIFF
--- a/.wrkstrm/clia/AGENCY.md
+++ b/.wrkstrm/clia/AGENCY.md
@@ -1,0 +1,26 @@
+# Agency Updates
+
+This document tracks agency updates and defines the standard format for recording them.
+
+## Update Format
+Each update is documented with a YAML metadata block immediately followed by the update text. The metadata captures key fields and attaches context to the update.
+
+Metadata block structure:
+
+```yaml
+id: <unique identifier>
+author: <name>
+date: <YYYY-MM-DD>
+status: <planned|in-progress|complete>
+```
+
+The metadata block must directly precede the associated update text with no blank lines in between.
+
+## Example
+```yaml
+id: 2024-06-12
+author: Project Manager
+date: 2024-06-12
+status: complete
+```
+Defined a unified standard for agency updates with YAML metadata blocks.


### PR DESCRIPTION
## Summary
- document a standard for agency update blocks and metadata fields
- relocate AGENCY.md to `.wrkstrm/clia` per repository guidelines

## Testing
- `swift test --skip-build`


------
https://chatgpt.com/codex/tasks/task_e_68b07b02a20883338bbb788e7f4e6b92