### PR TITLE
docs: ensure SDK naming consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fgoogle-gemini%2Fgenerative-ai-swift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/google-gemini/generative-ai-swift)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fgoogle-gemini%2Fgenerative-ai-swift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/google-gemini/generative-ai-swift)
 
-The Google AI Swift SDK is the easiest way for Swift developers to build with the Gemini API. The
+The Google AI SDK for Swift is the easiest way for Swift developers to build with the Gemini API. The
 Gemini API gives you access to Gemini [models](https://ai.google.dev/models/gemini) created by
 [Google DeepMind](https://deepmind.google/technologies/gemini/#introduction). Gemini models are
 built from the ground up to be multimodal, so you can reason seamlessly across text, images, and


### PR DESCRIPTION
## Summary
- use "Google AI SDK for Swift" consistently in README

## Testing
- `./scripts/style.sh README.md`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68b4857c47948333a6a0bc8a3914a903