### PR TITLE
Add trace logging to GenChatUI conversation flow

### DIFF
--- a/Sources/GenChatUI/Screens/ConversationScreen.swift
+++ b/Sources/GenChatUI/Screens/ConversationScreen.swift
@@ -88,6 +88,7 @@ public struct ConversationScreen: View {
       }
     }
     .navigationTitle("Chat sample")
+    .navigationBarTitleDisplayMode(.inline)
     .onAppear {
       focusedField = .message
     }

--- a/Sources/GenChatUI/ViewModels/ConversationViewModel.swift
+++ b/Sources/GenChatUI/ViewModels/ConversationViewModel.swift
@@ -16,6 +16,16 @@
 import Foundation
 import SwiftUI
 import GoogleGenerativeAI
+import WrkstrmLog
+
+extension Log {
+  /// Logger for GenChatUI conversation flow.
+  static let genChat = Log(
+    system: "GenChatUI",
+    category: "ConversationViewModel",
+    maxExposureLevel: .trace
+  )
+}
 
 @MainActor
 public class ConversationViewModel: ObservableObject {
@@ -46,6 +56,7 @@ public class ConversationViewModel: ObservableObject {
 
   public func sendMessage(_ text: String, streaming: Bool = true) async {
     error = nil
+    Log.genChat.trace("sendMessage streaming=\(streaming) text=\(text)")
     if streaming {
       await internalSendMessageStreaming(text)
     } else {
@@ -83,16 +94,18 @@ public class ConversationViewModel: ObservableObject {
       messages.append(systemMessage)
 
       do {
+        Log.genChat.trace("Sending streaming message: \(text)")
         let responseStream = chat.sendMessageStream(text)
         for try await chunk in responseStream {
           messages[messages.count - 1].pending = false
           if let text = chunk.text {
+            Log.genChat.trace("Received chunk text: \(text)")
             messages[messages.count - 1].message += text
           }
         }
       } catch {
         self.error = error
-        print(error.localizedDescription)
+        Log.genChat.trace("Streaming error: \(error.localizedDescription)")
         messages.removeLast()
       }
     }
@@ -116,17 +129,19 @@ public class ConversationViewModel: ObservableObject {
       messages.append(systemMessage)
 
       do {
+        Log.genChat.trace("Sending message: \(text)")
         var response: GenerateContentResponse?
         response = try await chat.sendMessage(text)
 
         if let responseText = response?.text {
+          Log.genChat.trace("Received response text: \(responseText)")
           // replace pending message with backend response
           messages[messages.count - 1].message = responseText
           messages[messages.count - 1].pending = false
         }
       } catch {
         self.error = error
-        print(error.localizedDescription)
+        Log.genChat.trace("Error: \(error.localizedDescription)")
         messages.removeLast()
       }
     }

--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -180,8 +180,12 @@ public final class GenerativeModel: @unchecked Sendable {
           systemInstruction: systemInstruction,
         ),
       )
+      Log.genAI.trace("generateContent request: \(generateContentRequest)")
       response = try await generativeAIService.loadRequest(
         request: generateContentRequest,
+      )
+      Log.genAI.trace(
+        "generateContent response: \(String(describing: response.candidates.first?.content))"
       )
     } catch {
       if let imageError = error as? ImageConversionError {
@@ -277,11 +281,13 @@ public final class GenerativeModel: @unchecked Sendable {
       request: generateContentRequest,
     )
     .makeAsyncIterator()
+    Log.genAI.trace("generateContentStream request: \(generateContentRequest)")
     return AsyncThrowingStream {
       let response: GenerateContentResponse?
       do {
         response = try await responseIterator.next()
       } catch {
+        Log.genAI.trace("generateContentStream error: \(error.localizedDescription)")
         throw GenerativeModel.generateContentError(from: error)
       }
 
@@ -291,6 +297,9 @@ public final class GenerativeModel: @unchecked Sendable {
         return nil
       }
 
+      Log.genAI.trace(
+        "generateContentStream chunk: \(String(describing: response.candidates.first?.content))"
+      )
       // Check the prompt feedback to see if the prompt was blocked.
       if response.promptFeedback?.blockReason != nil {
         throw GenerateContentError.promptBlocked(response: response)

--- a/Sources/GoogleAI/Logging.swift
+++ b/Sources/GoogleAI/Logging.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import WrkstrmLog
 
 #if canImport(OSLog)
 import OSLog
@@ -52,4 +53,13 @@ enum Logging {
   static let `default` = DummyLogger()
   static let verbose = DummyLogger()
   #endif
+}
+
+extension Log {
+  /// Logger for core GoogleGenerativeAI operations.
+  static let genAI = Log(
+    system: Logging.subsystem,
+    category: "GenerativeAI",
+    maxExposureLevel: .trace
+  )
 }

--- a/Tests/GoogleAITests/GenerateContentResponses/streaming-success-json-array-basic-reply.json
+++ b/Tests/GoogleAITests/GenerateContentResponses/streaming-success-json-array-basic-reply.json
@@ -1,0 +1,30 @@
+[
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            { "text": "Hello" }
+          ],
+          "role": "model"
+        },
+        "finishReason": "STOP"
+      }
+    ],
+    "usageMetadata": { "candidatesTokenCount": 1 }
+  },
+  {
+    "candidates": [
+      {
+        "content": {
+          "parts": [
+            { "text": " world" }
+          ],
+          "role": "model"
+        },
+        "finishReason": "STOP"
+      }
+    ],
+    "usageMetadata": { "candidatesTokenCount": 1 }
+  }
+]

--- a/Tests/GoogleAITests/GenerativeModelTests.swift
+++ b/Tests/GoogleAITests/GenerativeModelTests.swift
@@ -826,6 +826,23 @@ final class GenerativeModelTests: XCTestCase {  // swiftlint:disable:this type_b
     XCTAssertEqual(responses, 1)
   }
 
+  func testGenerateContentStream_successJsonArray() async throws {
+    MockURLProtocol
+      .requestHandler = try httpRequestHandler(
+        forResource: "streaming-success-json-array-basic-reply",
+        withExtension: "json",
+      )
+
+    var responses = 0
+    let stream = model.generateContentStream("Hi")
+    for try await content in stream {
+      XCTAssertNotNil(content.text)
+      responses += 1
+    }
+
+    XCTAssertEqual(responses, 2)
+  }
+
   func testGenerateContentStream_successUnknownSafetyEnum() async throws {
     MockURLProtocol
       .requestHandler = try httpRequestHandler(


### PR DESCRIPTION
## Summary
- integrate WrkstrmLog into GenChatUI
- add trace logging for sent messages and streaming/non-streaming responses
- expose core library loggers and trace network/model/chat flows
- log request payloads and failures in network service
- parse non-SSE streaming responses from the Google AI service
- force inline navigation title to avoid overlapping 'Chat sample' label
- cover JSON array streaming responses with tests

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f67f54ac8333b9420be8076926f3