### PR TITLE
feat: allow selecting models in GenChatUI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -60,6 +60,7 @@ let package = Package(
       name: "GenChatUI",
       dependencies: [
         "GoogleGenerativeAI",
+        .product(name: "WrkstrmNetworking", package: "WrkstrmFoundation"),
         .product(
           name: "MarkdownUI", package: "MarkdownUI",
           condition: .when(platforms: [.iOS, .macOS, .macCatalyst])),

--- a/Sources/GenChatUI/Screens/ConversationScreen.swift
+++ b/Sources/GenChatUI/Screens/ConversationScreen.swift
@@ -81,6 +81,25 @@ public struct ConversationScreen: View {
       .focused($focusedField, equals: .message)
     }
     .toolbar {
+      ToolbarItem(placement: .navigationBarLeading) {
+        Menu {
+          Button(ConversationViewModel.fallbackModelDisplayName) {
+            viewModel.selectModel(ConversationViewModel.fallbackModelName)
+          }
+          ForEach(
+            viewModel.availableModels.filter {
+              $0.name != ConversationViewModel.fallbackModelName
+            },
+            id: \.name
+          ) { model in
+            Button(model.displayName ?? model.name) {
+              viewModel.selectModel(model.name)
+            }
+          }
+        } label: {
+          Text(viewModel.modelDisplayName)
+        }
+      }
       ToolbarItem(placement: .primaryAction) {
         Button(action: newChat) {
           Image(systemName: "square.and.pencil")

--- a/Sources/GenChatUI/ViewModels/ConversationViewModel.swift
+++ b/Sources/GenChatUI/ViewModels/ConversationViewModel.swift
@@ -50,7 +50,8 @@ public class ConversationViewModel: ObservableObject {
   private let apiKey: String
 
   @Published public var availableModels: [ListModels.Model] = []
-  @Published public private(set) var selectedModelName: String
+  @Published public private(set) var selectedModelName: String = ConversationViewModel
+    .fallbackModelName
 
   public static let fallbackModelName = "gemini-1.5-flash-latest"
   public static let fallbackModelDisplayName = "Gemini 1.5 Flash"
@@ -59,7 +60,7 @@ public class ConversationViewModel: ObservableObject {
     self.apiKey = apiKey
     selectedModelName = Self.fallbackModelName
     model = GenerativeModel(
-      name: selectedModelName,
+      name: ConversationViewModel.fallbackModelName,
       apiKey: apiKey,
       systemInstruction: "Have a nice chat."
     )
@@ -82,7 +83,8 @@ public class ConversationViewModel: ObservableObject {
     guard selectedModelName != name else { return }
     let chosenName: String
     if name == Self.fallbackModelName
-      || availableModels.contains(where: { $0.name == name }) {
+      || availableModels.contains(where: { $0.name == name })
+    {
       chosenName = name
     } else {
       chosenName = Self.fallbackModelName

--- a/Sources/GenChatUI/ViewModels/ConversationViewModel.swift
+++ b/Sources/GenChatUI/ViewModels/ConversationViewModel.swift
@@ -17,6 +17,7 @@ import Foundation
 import SwiftUI
 import GoogleGenerativeAI
 import WrkstrmLog
+import WrkstrmNetworking
 
 extension Log {
   /// Logger for GenChatUI conversation flow.
@@ -46,12 +47,70 @@ public class ConversationViewModel: ObservableObject {
 
   private var chatTask: Task<Void, Never>?
 
+  private let apiKey: String
+
+  @Published public var availableModels: [ListModels.Model] = []
+  @Published public private(set) var selectedModelName: String
+
+  public static let fallbackModelName = "gemini-1.5-flash-latest"
+  public static let fallbackModelDisplayName = "Gemini 1.5 Flash"
+
   public init(apiKey: String) {
+    self.apiKey = apiKey
+    selectedModelName = Self.fallbackModelName
     model = GenerativeModel(
-      name: "gemini-1.5-flash-latest",
+      name: selectedModelName,
       apiKey: apiKey,
-      systemInstruction: "Have a nice chat.")
+      systemInstruction: "Have a nice chat."
+    )
     chat = model.startChat()
+
+    Task {
+      await loadModels()
+    }
+  }
+
+  public var modelDisplayName: String {
+    if selectedModelName == Self.fallbackModelName {
+      return Self.fallbackModelDisplayName
+    }
+    return availableModels.first { $0.name == selectedModelName }?.displayName
+      ?? selectedModelName
+  }
+
+  public func selectModel(_ name: String) {
+    guard selectedModelName != name else { return }
+    let chosenName: String
+    if name == Self.fallbackModelName
+      || availableModels.contains(where: { $0.name == name }) {
+      chosenName = name
+    } else {
+      chosenName = Self.fallbackModelName
+    }
+    selectedModelName = chosenName
+    model = GenerativeModel(
+      name: chosenName,
+      apiKey: apiKey,
+      systemInstruction: "Have a nice chat."
+    )
+    chat = model.startChat()
+    messages.removeAll()
+  }
+
+  private func loadModels() async {
+    do {
+      let environment = AI.GoogleGenAI.Environment.betaEnv(with: apiKey)
+      let client = HTTP.CodableClient(
+        environment: environment,
+        json: (.snakecase, .snakecase)
+      )
+      let response = try await client.send(
+        ListModels.Request(options: HTTP.Request.Options())
+      )
+      availableModels = response.models
+    } catch {
+      Log.genChat.error("Failed to load models: \(error.localizedDescription)")
+    }
   }
 
   public func sendMessage(_ text: String, streaming: Bool = true) async {


### PR DESCRIPTION
## Summary
- fetch available models and manage selection in `ConversationViewModel`, default to `gemini-1.5-flash-latest`
- add model picker menu to `ConversationScreen` with explicit fallback option
- include WrkstrmNetworking for model listing support

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68b5efd35418833391c1b9056d3a01a4