### PR TITLE
Add sidebar to GenChat sample

### DIFF
--- a/Examples/GenerativeAISample/ChatSample/ChatSampleApp.swift
+++ b/Examples/GenerativeAISample/ChatSample/ChatSampleApp.swift
@@ -17,15 +17,9 @@ import SwiftUI
 
 @main
 struct ChatSampleApp: App {
-  @StateObject
-  var viewModel = ConversationViewModel()
-
   var body: some Scene {
     WindowGroup {
-      NavigationStack {
-        ConversationScreen()
-          .environmentObject(viewModel)
-      }
+      ChatScreen()
     }
   }
 }

--- a/Sources/GenChatUI/Screens/ChatScreen.swift
+++ b/Sources/GenChatUI/Screens/ChatScreen.swift
@@ -1,0 +1,47 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+public struct ChatScreen: View {
+  @State private var chats: [UUID] = [UUID()]
+  @State private var selectedChat: UUID?
+  @StateObject private var viewModel = ConversationViewModel(apiKey: "")
+
+  public init() {}
+
+  public var body: some View {
+    NavigationSplitView {
+      List(chats, id: \.self, selection: $selectedChat) { chat in
+        if let index = chats.firstIndex(of: chat) {
+          Text("Chat \(index + 1)")
+        }
+      }
+      .navigationTitle("Chats")
+      .toolbar {
+        Button(action: newChat) {
+          Label("New Chat", systemImage: "square.and.pencil")
+        }
+      }
+      .onAppear {
+        if selectedChat == nil {
+          selectedChat = chats.first
+        }
+      }
+    } detail: {
+      if selectedChat != nil {
+        ConversationScreen()
+          .environmentObject(viewModel)
+      } else {
+        Text("Select a chat")
+      }
+    }
+  }
+
+  private func newChat() {
+    let chat = UUID()
+    chats.append(chat)
+    selectedChat = chat
+    viewModel.startNewChat()
+  }
+}
+
+#endif

--- a/Sources/GenChatUI/Screens/ChatScreen.swift
+++ b/Sources/GenChatUI/Screens/ChatScreen.swift
@@ -2,11 +2,15 @@
 import SwiftUI
 
 public struct ChatScreen: View {
+  private let apiKey: String
   @State private var chats: [UUID] = [UUID()]
   @State private var selectedChat: UUID?
-  @StateObject private var viewModel = ConversationViewModel(apiKey: "")
+  @StateObject private var viewModel: ConversationViewModel
 
-  public init() {}
+  public init(apiKey: String) {
+    self.apiKey = apiKey
+    _viewModel = StateObject(wrappedValue: ConversationViewModel(apiKey: apiKey))
+  }
 
   public var body: some View {
     NavigationSplitView {


### PR DESCRIPTION
## Summary
- Introduce a `ChatScreen` using `NavigationSplitView` to provide a sidebar-based chat layout
- Update the sample app to launch the new chat screen

## Testing
- `swift test`
- `swift run swiftformat Sources/GenChatUI/Screens/ChatScreen.swift Examples/GenerativeAISample/ChatSample/ChatSampleApp.swift` *(fails: no executable product named 'swiftformat')*

------
https://chatgpt.com/codex/tasks/task_e_68b5fb8c8b94833380603988bb7af4bf