### PR TITLE
Fix duplicate new chat buttons in GenChatUI

### DIFF
--- a/Sources/GenChatUI/Screens/ChatScreen.swift
+++ b/Sources/GenChatUI/Screens/ChatScreen.swift
@@ -2,49 +2,40 @@
 import SwiftUI
 
 public struct ChatScreen: View {
-  private let apiKey: String
-  @State private var chats: [UUID] = [UUID()]
-  @State private var selectedChat: UUID?
-  @StateObject private var viewModel: ConversationViewModel
+  @StateObject private var viewModel: ChatScreenViewModel
 
   public init(apiKey: String) {
-    self.apiKey = apiKey
-    _viewModel = StateObject(wrappedValue: ConversationViewModel(apiKey: apiKey))
+    _viewModel = StateObject(wrappedValue: ChatScreenViewModel(apiKey: apiKey))
   }
 
   public var body: some View {
     NavigationSplitView {
-      List(chats, id: \.self, selection: $selectedChat) { chat in
-        if let index = chats.firstIndex(of: chat) {
+      List(viewModel.chats, id: \.self, selection: $viewModel.selectedChat) { chat in
+        if let index = viewModel.chats.firstIndex(of: chat) {
           Text("Chat \(index + 1)")
         }
       }
       .navigationTitle("Chats")
-      .toolbar {
-        Button(action: newChat) {
-          Label("New Chat", systemImage: "square.and.pencil")
-        }
-      }
       .onAppear {
-        if selectedChat == nil {
-          selectedChat = chats.first
+        if viewModel.selectedChat == nil {
+          viewModel.selectedChat = viewModel.chats.first
         }
       }
     } detail: {
-      if selectedChat != nil {
+      if let conversationViewModel = viewModel.currentConversationViewModel {
         ConversationScreen()
-          .environmentObject(viewModel)
+          .environmentObject(conversationViewModel)
       } else {
         Text("Select a chat")
       }
     }
-  }
-
-  private func newChat() {
-    let chat = UUID()
-    chats.append(chat)
-    selectedChat = chat
-    viewModel.startNewChat()
+    .toolbar {
+      ToolbarItem(placement: .primaryAction) {
+        Button(action: viewModel.newChat) {
+          Label("New Chat", systemImage: "square.and.pencil")
+        }
+      }
+    }
   }
 }
 

--- a/Sources/GenChatUI/ViewModels/ChatScreenViewModel.swift
+++ b/Sources/GenChatUI/ViewModels/ChatScreenViewModel.swift
@@ -1,0 +1,30 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+@MainActor
+public final class ChatScreenViewModel: ObservableObject {
+  @Published public var chats: [UUID]
+  @Published public var selectedChat: UUID?
+  @Published public var conversationViewModels: [UUID: ConversationViewModel]
+  private let apiKey: String
+
+  public init(apiKey: String) {
+    self.apiKey = apiKey
+    let initialChat = UUID()
+    chats = [initialChat]
+    selectedChat = initialChat
+    conversationViewModels = [initialChat: ConversationViewModel(apiKey: apiKey)]
+  }
+
+  public func newChat() {
+    let chat = UUID()
+    chats.append(chat)
+    selectedChat = chat
+    conversationViewModels[chat] = ConversationViewModel(apiKey: apiKey)
+  }
+
+  public var currentConversationViewModel: ConversationViewModel? {
+    selectedChat.flatMap { conversationViewModels[$0] }
+  }
+}
+#endif


### PR DESCRIPTION
## Summary
- ensure GenChatUI only shows a single "New Chat" toolbar button by moving the toolbar to `NavigationSplitView`
- introduce `ChatScreenViewModel` to manage chat list and coordinate with `ConversationViewModel`
- maintain separate `ConversationViewModel` instances for each chat

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68b637a768b083338d9450fa5848ad0c