### PR TITLE
Consolidate chat actions into sidebar

### DIFF
--- a/Sources/GenChatUI/Screens/ChatScreen.swift
+++ b/Sources/GenChatUI/Screens/ChatScreen.swift
@@ -16,6 +16,13 @@ public struct ChatScreen: View {
         }
       }
       .navigationTitle("Chats")
+      .toolbar {
+        ToolbarItem(placement: .primaryAction) {
+          Button(action: viewModel.newChat) {
+            Label("New Chat", systemImage: "square.and.pencil")
+          }
+        }
+      }
       .onAppear {
         if viewModel.selectedChat == nil {
           viewModel.selectedChat = viewModel.chats.first
@@ -27,13 +34,6 @@ public struct ChatScreen: View {
           .environmentObject(conversationViewModel)
       } else {
         Text("Select a chat")
-      }
-    }
-    .toolbar {
-      ToolbarItem(placement: .primaryAction) {
-        Button(action: viewModel.newChat) {
-          Label("New Chat", systemImage: "square.and.pencil")
-        }
       }
     }
   }

--- a/Sources/GenChatUI/Screens/ConversationScreen.swift
+++ b/Sources/GenChatUI/Screens/ConversationScreen.swift
@@ -101,9 +101,7 @@ public struct ConversationScreen: View {
         }
       }
       ToolbarItem(placement: .primaryAction) {
-        Button(action: newChat) {
-          Image(systemName: "square.and.pencil")
-        }
+        Button("Clear", action: clearChat)
       }
     }
     .navigationTitle("Chat sample")
@@ -133,7 +131,7 @@ public struct ConversationScreen: View {
     }
   }
 
-  private func newChat() {
+  private func clearChat() {
     viewModel.startNewChat()
   }
 }


### PR DESCRIPTION
## Summary
- Move New Chat button to the chat sidebar to avoid duplicate controls
- Replace New Chat button in conversation view with text-based Clear action

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68b640a4541083339f0343e1be1326ac