### PR TITLE
feat: allow per-chat model selection

### DIFF
--- a/.wrkstrm/clia/AGENCY.md
+++ b/.wrkstrm/clia/AGENCY.md
@@ -36,3 +36,11 @@ date: 2025-09-02
 status: complete
 ```
 Shifted model loading to the screen view model and allowed each chat to select its own model.
+
+```yaml
+id: 2025-09-02-model-loading-guard
+author: ChatGPT
+date: 2025-09-02
+status: complete
+```
+Guarded new chat creation until models load and centralized logging across GenChatUI.

--- a/.wrkstrm/clia/AGENCY.md
+++ b/.wrkstrm/clia/AGENCY.md
@@ -28,3 +28,11 @@ status: complete
 ```
 
 Defined a unified standard for agency updates with YAML metadata blocks.
+
+```yaml
+id: 2025-09-02-model-ownership
+author: ChatGPT
+date: 2025-09-02
+status: complete
+```
+Shifted model loading to the screen view model and allowed each chat to select its own model.

--- a/Package.swift
+++ b/Package.swift
@@ -61,6 +61,7 @@ let package = Package(
       dependencies: [
         "GoogleGenerativeAI",
         .product(name: "WrkstrmNetworking", package: "WrkstrmFoundation"),
+        .product(name: "WrkstrmLog", package: "WrkstrmLog"),
         .product(
           name: "MarkdownUI", package: "MarkdownUI",
           condition: .when(platforms: [.iOS, .macOS, .macCatalyst])),

--- a/Sources/GenChatUI/Logging.swift
+++ b/Sources/GenChatUI/Logging.swift
@@ -1,0 +1,34 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import WrkstrmLog
+
+enum GenChatLogging {
+  /// Subsystem that should be used for all GenChatUI loggers.
+  static let subsystem = "com.google.genchatui"
+
+  /// Default category used for most loggers, unless specialized.
+  static let defaultCategory = ""
+}
+
+extension Log {
+  /// Logger for GenChatUI components.
+  static let genChat = Log(
+    system: GenChatLogging.subsystem,
+    category: "GenChatUI",
+    maxExposureLevel: .trace
+  )
+}
+

--- a/Sources/GenChatUI/ViewModels/ChatScreenViewModel.swift
+++ b/Sources/GenChatUI/ViewModels/ChatScreenViewModel.swift
@@ -31,16 +31,25 @@ public final class ChatScreenViewModel: ObservableObject {
   }
 
   public func newChat() {
-    let chat = UUID()
-    let viewModel = ConversationViewModel(
-      apiKey: apiKey,
-      availableModels: availableModels,
-      selectedModelName: defaultModelName
-    )
-    conversationViewModels[chat] = viewModel
-    chats.append(chat)
-    sortChatsByCreationDate()
-    selectedChat = chat
+    Task { @MainActor in
+      if availableModels.isEmpty {
+        await loadModels()
+      }
+      guard !availableModels.isEmpty else {
+        Log.genChat.warning("Models not loaded; new chat aborted")
+        return
+      }
+      let chat = UUID()
+      let viewModel = ConversationViewModel(
+        apiKey: apiKey,
+        availableModels: availableModels,
+        selectedModelName: defaultModelName
+      )
+      conversationViewModels[chat] = viewModel
+      chats.append(chat)
+      sortChatsByCreationDate()
+      selectedChat = chat
+    }
   }
 
   public func deleteChats(at offsets: IndexSet) {

--- a/Sources/GenChatUI/ViewModels/ConversationViewModel.swift
+++ b/Sources/GenChatUI/ViewModels/ConversationViewModel.swift
@@ -18,15 +18,6 @@ import SwiftUI
 import GoogleGenerativeAI
 import WrkstrmLog
 
-extension Log {
-  /// Logger for GenChatUI conversation flow.
-  static let genChat = Log(
-    system: "GenChatUI",
-    category: "ConversationViewModel",
-    maxExposureLevel: .trace
-  )
-}
-
 @MainActor
 public class ConversationViewModel: ObservableObject {
   /// This array holds both the user's and the system's chat messages


### PR DESCRIPTION
## Summary
- let ChatScreenViewModel fetch available models and supply defaults to new chats
- give ConversationViewModel ownership of its selected model
- wire GenChatUI to WrkstrmLog

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68b6515d37908333a52018dabe5de48e