### PR TITLE
feat: add chat-level model picker with confirmation

### DIFF
--- a/.wrkstrm/clia/AGENCY.md
+++ b/.wrkstrm/clia/AGENCY.md
@@ -44,3 +44,11 @@ date: 2025-09-02
 status: complete
 ```
 Guarded new chat creation until models load and centralized logging across GenChatUI.
+
+```yaml
+id: 2025-09-02-chat-model-picker
+author: ChatGPT
+date: 2025-09-02
+status: complete
+```
+Introduced a chat-level model picker with confirmation before changing models.


### PR DESCRIPTION
## Summary
- add chat-level model picker in conversation toolbar
- ask for confirmation before switching models
- track update in AGENCY log

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68b65cf125fc83339eb1549007842361