### PR TITLE
Scope model selection per chat

### DIFF
--- a/.wrkstrm/clia/AGENCY.md
+++ b/.wrkstrm/clia/AGENCY.md
@@ -52,3 +52,11 @@ date: 2025-09-02
 status: complete
 ```
 Introduced a chat-level model picker with confirmation before changing models.
+
+```yaml
+id: 2025-09-02-chat-header-model-scope
+author: ChatGPT
+date: 2025-09-02
+status: complete
+```
+Removed duplicate chat titles from conversation headers and scoped model changes to the active chat.

--- a/Sources/GenChatUI/Screens/ChatScreen.swift
+++ b/Sources/GenChatUI/Screens/ChatScreen.swift
@@ -39,6 +39,7 @@ public struct ChatScreen: View {
       if let conversationViewModel = viewModel.currentConversationViewModel {
         ConversationScreen()
           .environmentObject(conversationViewModel)
+          .id(conversationViewModel.id)
       } else {
         Text("Select a chat")
       }

--- a/Sources/GenChatUI/Screens/ConversationScreen.swift
+++ b/Sources/GenChatUI/Screens/ConversationScreen.swift
@@ -119,7 +119,7 @@ public struct ConversationScreen: View {
     } message: {
       Text("Switching models clears the current chat.")
     }
-    .navigationTitle("Chat sample")
+    .navigationTitle(viewModel.modelDisplayName)
     .navigationBarTitleDisplayMode(.inline)
     .onAppear {
       selectedModel = viewModel.selectedModelName

--- a/Sources/GenChatUI/ViewModels/ConversationViewModel.swift
+++ b/Sources/GenChatUI/ViewModels/ConversationViewModel.swift
@@ -38,6 +38,7 @@ public class ConversationViewModel: ObservableObject {
   private var chatTask: Task<Void, Never>?
 
   private let apiKey: String
+  public let id = UUID()
   public let creationDate: Date
 
   @Published public var availableModels: [ListModels.Model] = []


### PR DESCRIPTION
## Summary
- remove duplicate chat titles in conversation headers
- scope model picker state to each chat

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68b65fcfb324833388645cede837eb70